### PR TITLE
Proposal

### DIFF
--- a/AvaloniaTreeDataTemplateRepro/AvaloniaTreeDataTemplateRepro.csproj
+++ b/AvaloniaTreeDataTemplateRepro/AvaloniaTreeDataTemplateRepro.csproj
@@ -17,11 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview4" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview4" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview4" />
+    <PackageReference Include="Avalonia" Version="11.0.999-cibuild0030265-beta" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.999-cibuild0030265-beta" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.999-cibuild0030265-beta" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-preview4" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.999-cibuild0030265-beta" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.6.1" />
   </ItemGroup>

--- a/AvaloniaTreeDataTemplateRepro/ViewLocator.cs
+++ b/AvaloniaTreeDataTemplateRepro/ViewLocator.cs
@@ -6,7 +6,7 @@ using System;
 namespace AvaloniaTreeDataTemplateRepro;
 public class ViewLocator : IDataTemplate
 {
-    public IControl Build(object? data)
+    public Control Build(object? data)
     {
         var name = data!.GetType().FullName!.Replace("ViewModel", "View");
         var type = Type.GetType(name);

--- a/AvaloniaTreeDataTemplateRepro/Views/MainWindow.axaml
+++ b/AvaloniaTreeDataTemplateRepro/Views/MainWindow.axaml
@@ -14,13 +14,19 @@
     mc:Ignorable="d">
     <Grid RowDefinitions="*,*">
         <TreeView Items="{Binding Items}">
+            <TreeView.ItemTemplate>
+                <TreeDataTemplate DataType="vm:NodeViewModel" ItemsSource="{Binding Children}">
+                    <ContentControl Content="{Binding}" />
+                </TreeDataTemplate>
+            </TreeView.ItemTemplate>
+            
             <TreeView.DataTemplates>
-                <TreeDataTemplate DataType="vm:BranchNodeViewModel" ItemsSource="{Binding Children}">
-                    <TextBlock Text="{Binding Children.Count, StringFormat=[BranchNode - Children: {0}]}" />
-                </TreeDataTemplate>
-                <TreeDataTemplate DataType="vm:LeafNodeViewModel" ItemsSource="{Binding Children}">
-                    <TextBlock Text="[LeafNode]" />
-                </TreeDataTemplate>
+                <DataTemplate DataType="vm:BranchNodeViewModel">
+                    <TextBlock Text="{Binding Children.Count, StringFormat='Branch has {0} Children'}"></TextBlock>
+                </DataTemplate>
+                <DataTemplate DataType="vm:LeafNodeViewModel">
+                    <TextBlock Text="{Binding Children.Count, StringFormat='Leave has {0} Children'}"></TextBlock>
+                </DataTemplate>
             </TreeView.DataTemplates>
         </TreeView>
 


### PR DESCRIPTION
I found a way to make it work again. The idea is to have only one TreeDataTemplate (maybe a common interface is needed). You can still have different `DataTemplates` for individual nodes if you use a `ContentControl` as the content of the `TreeDataTemplate`